### PR TITLE
Multi authors

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -40,8 +40,12 @@
 
     {% if page.className == 'authors' %}
     <h3 class="author-articles">Articles by {{ author.name | truncatewords:1,"" }}</h3>
-    {% for post in articles %}
-     {% include postSummary.html %}
+
+    {% for post in site.posts %}
+      {% if post.author contains key %}
+        {% include postSummary.html %}
+      {% endif %}
     {% endfor %}
+
     {% endif %}
 </section>

--- a/_includes/postSummary.html
+++ b/_includes/postSummary.html
@@ -23,24 +23,28 @@
 
     <div class="cta flex">
         <div class="author flex-item">
+            {% assign authorCount = post.author | join: "," | split: "," | size %}
+            {% if authorCount > 1 # pluralize filter not working as expected %}
+            <header>Authors:</header>
+            {% else %}
             <header>Author:</header>
+            {% endif %}
+
             <p>
-        {% assign authorCount = post.author | size %}
-        {% if authorCount == 0 %}
-        No author
-        {% elsif authorCount == 1 %}
-        {{ post.author | first }}
-        {% else %}
-        {% for author in post.author %}
-        {% if forloop.first %}
-        {{ author }}
-        {% elsif forloop.last %}
-        and {{ author }}
-        {% else %}
-        , {{ author }}
-        {% endif %}
-        {% endfor %}
-        {% endif %}
+            {% if post.author == empty %}
+            No author
+            {% else %}
+              {% for a in post.author %}
+                {% assign author=site.data.authors[a] %}
+                {% if forloop.first %}
+                  <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% elsif forloop.last %}
+                  and <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% else %}
+                  , <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
             </p>
             </div>
 

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -30,9 +30,7 @@ isArticle: false
             <ul>
             {% for key in sortedAuthors %}
              {% assign author = site.data.authors[key] %}
-             {% assign articles = (site.posts | where: "author",key %}
-             {% if articles != empty and author.hasLeft != true %}
-
+             {% unless author.hasLeft %}
               {% if author.image %}
                   <li class="author--image" title="{{author.name}}">
                       <a href="/authors#{{ key }}">
@@ -40,7 +38,7 @@ isArticle: false
                       </a>
                   </li>
               {% endif %}
-             {% endif %}
+             {% endunless %}
             {% endfor %}
             </ul>
         </div>

--- a/authors/index.html
+++ b/authors/index.html
@@ -12,15 +12,11 @@ fixedHeader: true
 
 <div class="meet-author">
     {% for keyedAuthor in site.data.authors %}
-    {% assign key = keyedAuthor[0] %}
-    {% assign author = keyedAuthor[1] %}
-    {% assign articles = (site.posts | where: "author",key %}
+      {% assign key = keyedAuthor[0] %}
+      {% assign author = keyedAuthor[1] %}
 
-    {% if articles != empty %}
-    <div class="author-section hide">
+      <div class="author-section hide">
         {% include author.html %}
-    </div>
-    {% endif %}
+      </div>
     {% endfor %}
-
 </div>


### PR DESCRIPTION
Should be reasonably self-explanatory what each commit is addressing, but let me know if there's anything you're not sure about.

I am absolutely sure that there is something more elegant can be done, for instance, with the whole of site.posts being manually filtered by containing author as a loop for each author on that page, but without doing an upstream contribution into Jekyll to amend the 'where' filter and then us waiting for that to come downstream, I'm minded to try and be pragmatic about it.